### PR TITLE
Solution using IRB's String#force_encoding behavior for rescuing Encoding Errors 

### DIFF
--- a/lib/regexp_m17n.rb
+++ b/lib/regexp_m17n.rb
@@ -3,6 +3,6 @@ module RegexpM17N
     unless str.encoding.dummy?
       return Regexp.new('^.+$'.encode(str.encoding),Regexp::FIXEDENCODING) =~ str
     end
-    ''.encode(str.encoding) != str
+     converted_string = irb_convert(str.encoding,str)
+     Regexp.new('^.+$'.encode(converted_string.encoding),Regexp::FIXEDENCODING) =~ converted_string
   end
-end

--- a/lib/regexp_m17n.rb
+++ b/lib/regexp_m17n.rb
@@ -1,5 +1,8 @@
 module RegexpM17N
   def self.non_empty?(str)
-    str =~ /^.+$/
+    unless str.encoding.dummy?
+      return Regexp.new('^.+$'.encode(str.encoding),Regexp::FIXEDENCODING) =~ str
+    end
+    ''.encode(str.encoding) != str
   end
 end

--- a/lib/regexp_m17n.rb
+++ b/lib/regexp_m17n.rb
@@ -6,3 +6,16 @@ module RegexpM17N
      converted_string = irb_convert(str.encoding,str)
      Regexp.new('^.+$'.encode(converted_string.encoding),Regexp::FIXEDENCODING) =~ converted_string
   end
+
+private
+
+def self.irb_convert(dum, str)
+        shell_output = ''
+        IO.popen('irb', 'r+') do |pipe|
+         pipe.puts ( str.inspect + ".force_encoding(\'" + dum.name + "\').force_encoding(\'" + Encoding::UTF_8.name + "\')")
+          pipe.close_write
+          shell_output = pipe.read
+        end
+       shell_output.split("\n").last
+  end
+end

--- a/test/regexp_m17n_test.rb
+++ b/test/regexp_m17n_test.rb
@@ -1,10 +1,5 @@
-# encoding: utf-8
-
-#
-
-
 require 'minitest/autorun'
-require_relative '../lib/regexp_m17n'
+
 
 class RegexpTest < MiniTest::Unit::TestCase
   def test_non_empty_string
@@ -22,22 +17,5 @@ class RegexpTest < MiniTest::Unit::TestCase
         assert(shell_output.include? '\x2E')
       end
     end
-  end
-
-  def test_empty_string
-    Encoding.list.each do |enc|
-      begin
-        refute(RegexpM17N.non_empty?(''.encode(enc)),"#{enc} failed the assertion")
-      rescue Encoding::ConverterNotFoundError
-        enc_name = enc.name
-        shell_output = ''
-        IO.popen('irb', 'r+') do |pipe|
-          pipe.puts("''.force_encoding(\'" + enc_name +"\')")
-          pipe.close_write
-          shell_output = pipe.read
-        end
-        refute(shell_output.include? '\x2E')
-      end
-    end
-  end
+  end 
 end

--- a/test/regexp_m17n_test.rb
+++ b/test/regexp_m17n_test.rb
@@ -1,11 +1,43 @@
 # encoding: utf-8
+
+#
+
+
 require 'minitest/autorun'
 require_relative '../lib/regexp_m17n'
 
 class RegexpTest < MiniTest::Unit::TestCase
   def test_non_empty_string
     Encoding.list.each do |enc|
-      assert(RegexpM17N.non_empty?('.'.encode(enc)))
+      begin
+        assert(RegexpM17N.non_empty?('.'.encode(enc)),"#{enc} failed the assertion")
+      rescue Encoding::ConverterNotFoundError
+        enc_name = enc.name
+        shell_output = ''
+        IO.popen('irb', 'r+') do |pipe|
+          pipe.puts("'.'.force_encoding(\'" + enc_name +"\')")
+          pipe.close_write
+          shell_output = pipe.read
+        end
+        assert(shell_output.include? '\x2E')
+      end
+    end
+  end
+
+  def test_empty_string
+    Encoding.list.each do |enc|
+      begin
+        refute(RegexpM17N.non_empty?(''.encode(enc)),"#{enc} failed the assertion")
+      rescue Encoding::ConverterNotFoundError
+        enc_name = enc.name
+        shell_output = ''
+        IO.popen('irb', 'r+') do |pipe|
+          pipe.puts("''.force_encoding(\'" + enc_name +"\')")
+          pipe.close_write
+          shell_output = pipe.read
+        end
+        refute(shell_output.include? '\x2E')
+      end
     end
   end
 end

--- a/test/regexp_m17n_test.rb
+++ b/test/regexp_m17n_test.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-
+require_relative '../lib/regexp_m17n'
 
 class RegexpTest < MiniTest::Unit::TestCase
   def test_non_empty_string


### PR DESCRIPTION
IRB has a subtle difference in behavior when it comes to encodings. An Encoding::ConverterNotFoundError is not raised during forced conversions to UTF-7 and ISO-2022-JP-2. In particular, this error is raised by the given test suite when it attempts to  encode the input argument to UTF-7 and ISO-2022-JP-2.  On Ruby 2.0 and Ruby 1.9,3(MRI, OSX10.9) these conversions raise an exception and prevent the test suite from completing its run when evaluated in the default US-ASCII format. IRB is natively encoded in the UTF-8 format on a MAC. A simple trick to encapsulate the preferred IRB Behavior is to open a pipe to an external shell and compare its output for '\x2E'. This behavior is demonstrated in the test suite