### PR TITLE
Conversion with encodings and monkey patch

### DIFF
--- a/lib/regexp_m17n.rb
+++ b/lib/regexp_m17n.rb
@@ -4,7 +4,7 @@ module RegexpM17N
       def encode(string)
         ec = Encoding::Converter.new(self.encoding, string)
         ec.convert(self)
-      rescue Encoding::ConverterNotFoundError
+      rescue Encoding::ConverterNotFoundError, Java::JavaNioCharset::UnsupportedCharsetException
         self.force_encoding(string)
       end
     end

--- a/lib/regexp_m17n.rb
+++ b/lib/regexp_m17n.rb
@@ -1,5 +1,25 @@
 module RegexpM17N
   def self.non_empty?(str)
-    str =~ /^.+$/
+    String.class_eval do
+      def encode(string)
+        ec = Encoding::Converter.new(self.encoding, string)
+        ec.convert(self)
+      rescue Encoding::ConverterNotFoundError
+        self.force_encoding(string)
+      end
+    end
+
+    regexp = '^.+$'
+    encoding = Encoding.find(str.encoding)
+
+    string = if encoding.dummy?
+      str.encode('UTF-8')
+    else
+      regexp = regexp.encode(str.encoding)
+      str
+    end
+    regexp = Regexp.new(regexp)
+
+    regexp =~ string
   end
 end


### PR DESCRIPTION
Convert the regexp properly and get rid of Exception raised when invoking `non_empty?`
with the `'.'.encode` method call with the monkey patch