### PR TITLE
encode both str and regex to BINARY

### DIFF
--- a/lib/regexp_m17n.rb
+++ b/lib/regexp_m17n.rb
@@ -1,5 +1,5 @@
 module RegexpM17N
   def self.non_empty?(str)
-    str =~ /^.+$/
+    str.encode(Encoding::BINARY) =~ Regexp.new('^.+$'.encode(Encoding::BINARY))
   end
 end

--- a/test/regexp_m17n_test.rb
+++ b/test/regexp_m17n_test.rb
@@ -5,7 +5,13 @@ require_relative '../lib/regexp_m17n'
 class RegexpTest < MiniTest::Unit::TestCase
   def test_non_empty_string
     Encoding.list.each do |enc|
-      assert(RegexpM17N.non_empty?('.'.encode(enc)))
+      begin
+        str = '.'.encode(enc)
+      rescue
+        # ruby can't encoding ISO-2022-JP-2 and UTF-7 yet. This is bug in the test, not non_empty? method
+        next
+      end
+      assert(RegexpM17N.non_empty?(str))
     end
   end
 end


### PR DESCRIPTION
`'.'` can't encode to `ISO-2022-JP-2 (dummy)` and `UTF-7 (dummy)`yet, otherwise we can convert string and regex to BINARY (ASCII-8BIT)